### PR TITLE
Force successful return code on setup_remote_state.

### DIFF
--- a/scripts/setup_remote_state.sh
+++ b/scripts/setup_remote_state.sh
@@ -21,3 +21,5 @@ docker run \
     --env-file env \
     mesosphere/aws-cli:latest \
     dynamodb create-table --table-name terraform-lock-testing-express-api --attribute-definitions AttributeName=LockID,AttributeType=S --key-schema AttributeName=LockID,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 --region "$AWS_REGION"
+
+exit 0


### PR DESCRIPTION
The AWS CLI will return a non-successful status code if the objects
we're creating are already present. As a workaround (which needs to be
properly fixed), we'll `exit 0` regardless of previous return codes.